### PR TITLE
Dispose pixmap in constructor

### DIFF
--- a/src/io/anuke/gif/GifRecorder.java
+++ b/src/io/anuke/gif/GifRecorder.java
@@ -73,6 +73,8 @@ public class GifRecorder{
 		pixmap.fill();
 
 		region = new TextureRegion(new Texture(pixmap));
+		
+		pixmap.dispose();
 	}
 
 	protected void doInput(){


### PR DESCRIPTION
After being uploaded to the texture, the pixmap is no longer required.